### PR TITLE
Invoke bashcompinit when using on zsh

### DIFF
--- a/um-completion.sh
+++ b/um-completion.sh
@@ -57,6 +57,6 @@ _um()
 
 if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
    # assume Zsh
-   autoload bashcompinit && bachcompinit
+   autoload bashcompinit && bashcompinit
 fi
 complete -F _um um

--- a/um-completion.sh
+++ b/um-completion.sh
@@ -53,4 +53,10 @@ _um()
     return 0
 }
     
+# Check if shell is zsh and if so invoke bash-compatible completion.
+
+if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
+   # assume Zsh
+   autoload bashcompinit && bachcompinit
+fi
 complete -F _um um


### PR DESCRIPTION
Hello!

Super utility here. I use `zsh` and the autocomplete relies on bash `complete` which is not enabled in `zsh` by default. Using `bashcompinit` makes `complete` available to `zsh`.

I just inserted a shell check into `um-completion.sh` and when it finds `zsh` it loads `bashcompinit`. This works on my systems but I will readily admit I just learned about `bash` completion and loading `bashcompinit` in the last hour or so, so I hope I've not introduced some stupid bug(s).

Cheers!