### PR TITLE
Make rake invocation less verbose

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,8 +24,8 @@ desc 'Converts Markdown man pages to troff man files.'
 task :man => OUTPUT_FILES
 CLOBBER.include(OUTPUT_DIR)
 
+mkdir_p OUTPUT_DIR if !Dir.exist?(OUTPUT_DIR)
 rule OUTPUT_EXT => -> (name) { out_to_source(name) } do |t|
-  mkdir_p t.name.pathmap('%d')
   doc = Kramdown::Document.new(File.read(t.source))
   File.write(t.name, doc.to_man)
 end


### PR DESCRIPTION
Only create the output directory if needed.

This is my first time coding in Ruby, so any hint about better format/coding style would be welcome ;)
In the [AUR package](https://aur.archlinux.org/packages/um-git/) someone suggested to remove the multiple `mkdir -p doc/man1` output lines, when building the package.

So now you only see this line once and only if the directory did not exist beforehand.