### PR TITLE
Add Arch Linux AUR packages to install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,18 @@ Kramdown, so they could also make a good reference.
 
 ## Installation
 
-### MacOS
-You can install `um` via [Homebrew](http://brew.sh/):
+<a href="https://repology.org/metapackage/um/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/um.svg" alt="Packaging status" align="right">
+</a>
+
+* **MacOS:** `um` is available via [Homebrew](http://brew.sh/):
 ```
 $ brew install sinclairtarget/wst/um
 ```
 
-### Linux
+* **Arch Linux:** `um` is available via the AUR in two versions: the release version [`um`](https://aur.archlinux.org/packages/um/) and the latest master [`um-git`](https://aur.archlinux.org/packages/um-git/)
 
-You can install `um` via [Linux Brew](http://linuxbrew.sh/):
-
+* **Linux Brew:** `um` is available via [Linux Brew](http://linuxbrew.sh/):
 ```
 $ brew install sinclairtarget/wst/um
 ```


### PR DESCRIPTION
Added a [badge](https://repology.org/metapackage/um/badges) to quickly have a glance in which repositories `um` has been packaged in.

If `um` makes it into Homebrew core, then it should automatically be added to that list. This would also be the case if `um` was packaged for one of the other repositories repology supports.

If you do not like the badge, then you can of course remove it. It is just a suggestion that was inspired by this readme: https://github.com/jaagr/polybar#getting-started