### PR TITLE
Use Etc.getpwuid.name instead of Etc.getlogin

### DIFF
--- a/lib/um/topic.rb
+++ b/lib/um/topic.rb
@@ -26,7 +26,7 @@ module Topic
     private
 
     def topic_file_path
-      tmp_dir_path = '/var/tmp/um/' + Etc.getlogin
+      tmp_dir_path = '/var/tmp/um/' + Etc.getpwuid.name
       FileUtils.mkdir_p tmp_dir_path
 
       tmp_dir_path + '/current.topic'

--- a/lib/um/umconfig.rb
+++ b/lib/um/umconfig.rb
@@ -110,7 +110,7 @@ class UmConfig
     # Cache the current pages directory in a file. This is used by the bash
     # completion script to avoid spinning up Ruby.
     def write_pages_directory(pages_directory_path)
-      tmp_dir_path = '/var/tmp/um/' + Etc.getlogin
+      tmp_dir_path = '/var/tmp/um/' + Etc.getpwuid.name
       FileUtils.mkdir_p tmp_dir_path
 
       tmp_file_path = tmp_dir_path + '/current.pagedir'


### PR DESCRIPTION
This fix is specifically for running `um` inside a Docker container.

For some reason `Etc.getlogin` returns `nil` when inside a Docker container. I'm not sure of the reason why that's so, but some light searching pointed to recommendations to use `Etc.getpwuid` instead of `Etc.getlogin` anyway. (https://www.rubydoc.info/stdlib/etc/Etc.getlogin)

**Reproduction steps:**

Dockerfile
```dockerfile
FROM ruby:2.6.5-buster

RUN git clone https://github.com/sinclairtarget/um.git \
  && cd um \
  && gem build *.gemspec \
  && gem install um*.gem

CMD ["um", "list"] 
```

Building and running that produces this output:

```
/usr/local/bundle/gems/um-4.2.0/lib/um/umconfig.rb:113:in `+': no implicit conversion of nil into String (TypeError)
        from /usr/local/bundle/gems/um-4.2.0/lib/um/umconfig.rb:113:in `write_pages_directory'
        from /usr/local/bundle/gems/um-4.2.0/lib/um/umconfig.rb:78:in `source'
        from /usr/local/bundle/gems/um-4.2.0/libexec/um-list.rb:18:in `<main>'
```

**With patch:**

Dockerfile
```dockerfile
FROM ruby:2.6.5-buster

RUN git clone --single-branch --branch b-ggs/getpwuid https://github.com/b-ggs/um.git \
  && cd um \
  && gem build *.gemspec \
  && gem install um*.gem

CMD ["um", "list"]
```

Now, running that presents the expected output:

```
No pages found for topic "shell."
```